### PR TITLE
ステップ12: タスク一覧を作成日時の順番で並び替えよう

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def show; end

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -2,7 +2,7 @@ h1 タスク一覧
 
 ul
   - @tasks.each do |task|
-    li
+    li.task_list
        = link_to task.name, task_path(task.id)
        = link_to ' 編集', edit_task_path(task.id)
        = link_to ' 削除', task, method: :delete, data: { confirm: 'タスクを削除しますか？' }

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -2,10 +2,15 @@ require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
   describe 'index' do
-    let!(:task) { create(:task) }
-    it 'タスクが表示される' do
+    it 'タスクが作成日の降順で表示される' do
+      old_task = create(:task, name: '古いタスク')
+      new_task = create(:task, name: '新しいタスク')
+      old_task.update(name: '古いタスクを更新') # 更新しても順番が変わらないことを確認するため
+
       visit tasks_path
-      expect(page).to have_content task.name
+      tasks = all('.task_list')
+      expect(tasks[0]).to have_content new_task.name
+      expect(tasks[1]).to have_content old_task.name
     end
   end
 


### PR DESCRIPTION
### 仕様
[ステップ12: タスク一覧を作成日時の順番で並び替えよう](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%82%88%E3%81%86)

* 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
* 並び替えがうまく行っていることをsystem specで書いてみましょう

### やったこと
1. タスク一覧を作成日降順に変更
2. system testの作成

### 確認したこと
* 作成日降順でタスクが表示されること
* テストが通ること
