### PR TITLE
ステップ14: 終了期限を追加しよう

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,10 @@ Style/IfUnlessModifier:
 Style/NumericLiterals:
   MinDigits: 7
 
+# Lambda処理をすべてアロー演算子で表記する（デフォルトは1行: アロー演算子, 複数行: Lambda）
+Style/Lambda:
+  EnforcedStyle: literal
+
 ######## Layout ########
 # private/protected は一段深くインデントする
 Layout/IndentationConsistency:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ entity tasks {
   description: text
   status: integer
   priority: integer
-  end_period: datetime
+  end_date: datetime
   user_id: integer (FK)
 }
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.all.order(created_at: :desc)
+    @tasks = Task.order(created_at: :desc)
   end
 
   def show; end
@@ -46,6 +46,6 @@ class TasksController < ApplicationController
     end
 
     def task_params
-      params.require(:task).permit(:name, :description)
+      params.require(:task).permit(:name, :description, :end_date)
     end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.end_date_sort(params[:end_date_sort_flag]).order(created_at: :desc)
+    @tasks = Task.end_date_sort(params[:end_date_sort_key]).order(created_at: :desc)
   end
 
   def show; end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.end_date_sort(params[:end_date]).order(created_at: :desc)
+    @tasks = Task.end_date_sort(params[:end_date_sort_flag]).order(created_at: :desc)
   end
 
   def show; end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
-    @tasks = Task.order(created_at: :desc)
+    @tasks = Task.end_date_sort(params[:end_date]).order(created_at: :desc)
   end
 
   def show; end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,6 +6,7 @@ class Task < ApplicationRecord
     case sort_key&.downcase
     when 'asc' then order(end_date: :asc)
     when 'desc' then order('end_date IS NULL, end_date desc')
+    else order(end_date: :asc)
     end
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,11 @@
 class Task < ApplicationRecord
   validates :name, presence: true, length: { in: 1..50 }
   validates :description, length: { maximum: 1000 }
+
+  scope :end_date_sort, lambda { |sort_method|
+    case sort_method.downcase
+    when 'asc' then order(end_date: :asc)
+    when 'desc' then order('end_date IS NULL, end_date desc')
+    end
+  }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,8 +2,8 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { in: 1..50 }
   validates :description, length: { maximum: 1000 }
 
-  scope :end_date_sort, ->(sort_method) do
-    case sort_method&.downcase
+  scope :end_date_sort, ->(sort_flag) do
+    case sort_flag&.downcase
     when 'asc' then order(end_date: :asc)
     when 'desc' then order('end_date IS NULL, end_date desc')
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,10 +2,10 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { in: 1..50 }
   validates :description, length: { maximum: 1000 }
 
-  scope :end_date_sort, lambda { |sort_method|
+  scope :end_date_sort, ->(sort_method) do
     case sort_method&.downcase
     when 'asc' then order(end_date: :asc)
     when 'desc' then order('end_date IS NULL, end_date desc')
     end
-  }
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,7 +3,7 @@ class Task < ApplicationRecord
   validates :description, length: { maximum: 1000 }
 
   scope :end_date_sort, lambda { |sort_method|
-    case sort_method.downcase
+    case sort_method&.downcase
     when 'asc' then order(end_date: :asc)
     when 'desc' then order('end_date IS NULL, end_date desc')
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,8 +2,8 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { in: 1..50 }
   validates :description, length: { maximum: 1000 }
 
-  scope :end_date_sort, ->(sort_flag) do
-    case sort_flag&.downcase
+  scope :end_date_sort, ->(sort_key) do
+    case sort_key&.downcase
     when 'asc' then order(end_date: :asc)
     when 'desc' then order('end_date IS NULL, end_date desc')
     end

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -15,4 +15,8 @@
     = form.text_area :description, size: "45x5", maxlength: 1000
 
   .
+    p = form.label :end_date
+    = form.date_field :end_date
+
+  .
     = form.submit

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -4,7 +4,13 @@ table
   thead
     tr
       th タスク名
-      th 終了期限
+      th
+        - if request.fullpath.include?('desc')
+          = link_to '終了期限▼', end_date: 'asc'
+        - elsif request.fullpath.include?('asc')
+          = link_to '終了期限▲', end_date: 'desc'
+        - else
+          = link_to '終了期限', end_date: 'desc'
   tbody
     - @tasks.each do |task|
       tr.task_list

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -6,11 +6,11 @@ table
       th タスク名
       th
         - if request.fullpath.include?('desc')
-          = link_to '終了期限▼', end_date: 'asc'
+          = link_to '終了期限▼', tasks_path(end_date: 'asc'), id: 'end_date_title'
         - elsif request.fullpath.include?('asc')
-          = link_to '終了期限▲', end_date: 'desc'
+          = link_to '終了期限▲', tasks_path(end_date: 'desc'), id: 'end_date_title'
         - else
-          = link_to '終了期限', end_date: 'desc'
+          = link_to '終了期限', tasks_path(end_date: 'asc'), id: 'end_date_title'
   tbody
     - @tasks.each do |task|
       tr.task_list

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -6,11 +6,11 @@ table
       th タスク名
       th
         - if request.fullpath.include?('desc')
-          = link_to '終了期限▼', tasks_path(end_date: 'asc'), id: 'end_date_title'
+          = link_to '終了期限▼', tasks_path(end_date_sort_flag: 'asc'), id: 'end_date_title'
         - elsif request.fullpath.include?('asc')
-          = link_to '終了期限▲', tasks_path(end_date: 'desc'), id: 'end_date_title'
+          = link_to '終了期限▲', tasks_path(end_date_sort_flag: 'desc'), id: 'end_date_title'
         - else
-          = link_to '終了期限', tasks_path(end_date: 'asc'), id: 'end_date_title'
+          = link_to '終了期限', tasks_path(end_date_sort_flag: 'asc'), id: 'end_date_title'
   tbody
     - @tasks.each do |task|
       tr.task_list

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,8 +1,14 @@
 h1 タスク一覧
 
-ul
-  - @tasks.each do |task|
-    li.task_list
-       = link_to task.name, task_path(task.id)
-       = link_to ' 編集', edit_task_path(task.id)
-       = link_to ' 削除', task, method: :delete, data: { confirm: 'タスクを削除しますか？' }
+table
+  thead
+    tr
+      th タスク名
+      th 終了期限
+  tbody
+    - @tasks.each do |task|
+      tr.task_list
+        td = link_to task.name, task
+        td = task.end_date
+        td = link_to '編集', edit_task_path(task)
+        td = link_to '削除', task, method: :delete, data: { confirm: 'タスクを削除しますか？' }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -6,11 +6,11 @@ table
       th タスク名
       th
         - if request.fullpath.include?('desc')
-          = link_to '終了期限▼', tasks_path(end_date_sort_flag: 'asc'), id: 'end_date_title'
+          = link_to '終了期限▼', tasks_path(end_date_sort_key: 'asc'), id: 'end_date_title'
         - elsif request.fullpath.include?('asc')
-          = link_to '終了期限▲', tasks_path(end_date_sort_flag: 'desc'), id: 'end_date_title'
+          = link_to '終了期限▲', tasks_path(end_date_sort_key: 'desc'), id: 'end_date_title'
         - else
-          = link_to '終了期限', tasks_path(end_date_sort_flag: 'asc'), id: 'end_date_title'
+          = link_to '終了期限', tasks_path(end_date_sort_key: 'asc'), id: 'end_date_title'
   tbody
     - @tasks.each do |task|
       tr.task_list

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -2,5 +2,9 @@ h1 タスク詳細
 
 h2 = @task.name
 p = @task.description
+p
+  | 終了期限: 
+  = @task.end_date
+
 = link_to '編集', edit_task_path(@task.id)
 = link_to ' 削除', @task, method: :delete, id: 'task_delete', data: { confirm: 'タスクを削除しますか？' }

--- a/db/migrate/20200827044330_add_end_date_to_task.rb
+++ b/db/migrate/20200827044330_add_end_date_to_task.rb
@@ -1,0 +1,5 @@
+class AddEndDateToTask < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :end_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_21_080305) do
+ActiveRecord::Schema.define(version: 2020_08_27_044330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_08_21_080305) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "name", null: false
     t.text "description"
+    t.date "end_date"
   end
 
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -12,6 +12,21 @@ RSpec.describe 'Tasks', type: :system do
       expect(tasks[0]).to have_content new_task.name
       expect(tasks[1]).to have_content old_task.name
     end
+
+    it 'タスクを終了期限でソートできる' do
+      slow_end_date_task = create(:task, name: '期限が遅いタスク', end_date: '2020-02-01')
+      early_end_date_task = create(:task, name: '期限が早いタスク', end_date: '2020-01-01')
+
+      visit tasks_path
+
+      click_link 'end_date_title'
+      tasks = all('.task_list')
+      expect(tasks[0]).to have_content early_end_date_task.name
+
+      click_link 'end_date_title'
+      tasks = all('.task_list')
+      expect(tasks[0]).to have_content slow_end_date_task.name
+    end
   end
 
   describe 'show' do


### PR DESCRIPTION
### 仕様
[ステップ14: 終了期限を追加しよう](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9714-%E7%B5%82%E4%BA%86%E6%9C%9F%E9%99%90%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)
* タスクに対して、終了期限を登録できるようにしてみましょう
* 一覧画面で、終了期限でソートできるようにしましょう
* specを拡充しましょう

### やったこと
1. task modelに終了期限カラム追加
2. taskのフォームに終了期限の項目を追加
3. 終了期限のソート切り替えを実装
4. 終了期限のソートのspec作成

### 確認したこと
* 終了期限が入力・登録・編集できること
* 終了期限がソートされること
* 終了期限のソートが切り替えできること

### 画面
![tasks_sort](https://user-images.githubusercontent.com/43537209/91423108-10ec9c80-e893-11ea-99c6-d9337c34a666.gif)
