### PR TITLE
ステップ22: ユーザにロールを追加しよう

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,0 +1,10 @@
+class Admin::AdminController < ApplicationController
+  class NotAuthorizedError < StandardError; end
+  before_action :admin_required
+
+  private
+
+  def admin_required
+    raise NotAuthorizedError, '権限がありません。' unless current_user.admin?
+  end
+end

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -1,6 +1,4 @@
-class Admin::TasksController < ApplicationController
-  before_action :admin_required
-
+class Admin::TasksController < Admin::AdminController
   def index
     @q = User.find(params[:user_id]).tasks.ransack(params[:q])
     @tasks = @q.result.page(params[:page]).order(created_at: :desc)

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -1,4 +1,6 @@
 class Admin::TasksController < ApplicationController
+  before_action :admin_required
+
   def index
     @q = User.find(params[:user_id]).tasks.ransack(params[:q])
     @tasks = @q.result.page(params[:page]).order(created_at: :desc)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -37,10 +37,10 @@ class Admin::UsersController < ApplicationController
       redirect_to admin_users_path, notice: 'ユーザーを削除しました。'
     else
       error_messages = if @user.errors.any?
-                        @user.errors.full_messages.join('\n')
-                      else
-                        '不明な理由で、ユーザーの削除に失敗しました。'
-                      end
+                         @user.errors.full_messages.join('\n')
+                       else
+                         '不明な理由で、ユーザーの削除に失敗しました。'
+                       end
       redirect_to admin_users_path, alert: error_messages
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,4 @@
-class Admin::UsersController < ApplicationController
-  before_action :admin_required
+class Admin::UsersController < Admin::AdminController
   before_action :set_user, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -36,7 +36,12 @@ class Admin::UsersController < ApplicationController
     if @user.destroy
       redirect_to admin_users_path, notice: 'ユーザーを削除しました。'
     else
-      redirect_to admin_users_path, alert: 'ユーザーの削除に失敗しました。'
+      error_message = if @user.errors.any?
+                        @user.errors.full_messages.join('\n')
+                      else
+                        '不明な理由で、ユーザーの削除に失敗しました。'
+                      end
+      redirect_to admin_users_path, alert: error_message
     end
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -36,12 +36,12 @@ class Admin::UsersController < ApplicationController
     if @user.destroy
       redirect_to admin_users_path, notice: 'ユーザーを削除しました。'
     else
-      error_message = if @user.errors.any?
+      error_messages = if @user.errors.any?
                         @user.errors.full_messages.join('\n')
                       else
                         '不明な理由で、ユーザーの削除に失敗しました。'
                       end
-      redirect_to admin_users_path, alert: error_message
+      redirect_to admin_users_path, alert: error_messages
     end
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,5 @@
 class Admin::UsersController < ApplicationController
+  before_action :admin_required
   before_action :set_user, only: %i[show edit update destroy]
 
   def index
@@ -46,6 +47,6 @@ class Admin::UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  class NotAuthorizedError < StandardError; end
   helper_method :current_user
   before_action :login_required
 
@@ -10,5 +11,9 @@ class ApplicationController < ActionController::Base
 
   def login_required
     redirect_to login_path unless current_user
+  end
+
+  def admin_required
+    raise NotAuthorizedError, '権限がありません。' unless current_user.admin?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  class NotAuthorizedError < StandardError; end
   helper_method :current_user
   before_action :login_required
 
@@ -11,9 +10,5 @@ class ApplicationController < ActionController::Base
 
   def login_required
     redirect_to login_path unless current_user
-  end
-
-  def admin_required
-    raise NotAuthorizedError, '権限がありません。' unless current_user.admin?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,18 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :tasks, dependent: :destroy
+  after_destroy :one_or_more_admin_users
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
   validates :admin, inclusion: { in: [true, false] }
 
   scope :join_tasks_count, -> { left_joins(:tasks).select('users.*, COUNT(tasks.id) AS tasks_count').group(:id) }
+
+  def one_or_more_admin_users
+    return if User.where(admin: true).size.positive?
+
+    errors.add :admin, '管理者が0人になるため削除できません。'
+    raise ActiveRecord::Rollback
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
+  validates :admin, inclusion: { in: [true, false] }
 
   scope :join_tasks_count, -> { left_joins(:tasks).select('users.*, COUNT(tasks.id) AS tasks_count').group(:id) }
 end

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,4 +1,5 @@
-= form_with  url: path, model: user, local: true do |form|
+/ = form_with  url: path, model: user, local: true do |form|
+= form_with model: [:admin, user], local: true do |form|
   - if user.errors.any?
     #error_explanation
       h2 ユーザーが保存されませんでした

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -16,6 +16,11 @@
     = form.email_field :email, required: true
 
   .
+    p = form.label :admin
+    = form.check_box :admin
+      | 管理者権限
+
+  .
     p = form.label :password
     = form.password_field :password, required: true
 

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,3 +1,3 @@
 h1 ユーザー編集
 
-= render 'form', user: @user, path: admin_user_path(@user)
+= render 'form', user: @user

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -5,6 +5,7 @@ table
     tr
       th = User.human_attribute_name(:name)
       th = User.human_attribute_name(:email)
+      th = User.human_attribute_name(:admin)
       th = User.human_attribute_name(:tasks_count)
 
   tbody
@@ -12,6 +13,7 @@ table
       tr.user_list
         td = link_to user.name, admin_user_path(user)
         td = user.email
+        td = user.admin? ? 'あり' : 'なし'
         td#tasks_count = user.tasks_count
         td = link_to '編集', edit_admin_user_path(user)
         td = link_to '削除', admin_user_path(user), method: :delete, data: { confirm: 'ユーザーを削除しますか？' }

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,3 +1,3 @@
 h1 ユーザー作成
 
-= render 'form', user: @user, path: admin_users_path
+= render 'form', user: @user

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -3,5 +3,8 @@ ul
     li = link_to  "タスク一覧", tasks_path
     li = link_to  "タスク作成", new_task_path
     li = link_to 'ログアウト', logout_path, method: :delete
+    - if current_user.admin?
+      li = link_to  "ユーザ一覧", admin_users_path
+      li = link_to  "ユーザ作成", new_admin_user_path
   - else
-   li = link_to 'ログイン', login_path
+    li = link_to 'ログイン', login_path

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
     attributes:
       user:
         email: メールアドレス
+        admin: 管理者権限
         password: パスワード
         password_confirmation: パスワード確認
         tasks_count: タスク数

--- a/db/migrate/20200903031023_add_admin_to_users.rb
+++ b/db/migrate/20200903031023_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_092936) do
+ActiveRecord::Schema.define(version: 2020_09_03_031023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2020_09_01_092936) do
     t.string "name", null: false
     t.string "email", null: false
     t.string "password_digest", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["created_at"], name: "index_users_on_created_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,7 @@ end
 seed_user = User.create!(
   name: 'seed user',
   email: 'seed@example.com',
+  admin: true,
   password: 'seed_password',
   password_confirmation: 'seed_password'
 )

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,4 +5,16 @@ RSpec.describe User, type: :model do
     let(:user) { build(:user) }
     it { expect(user).to be_valid }
   end
+
+  describe 'callback' do
+    describe '管理者の削除' do
+      let!(:admin_user) { create(:user, admin: true) }
+      context '管理者が1人の時' do
+        it '管理者を削除できない' do
+          expect(User.where(admin: true).size).to eq 1
+          expect { admin_user.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,9 +9,16 @@ RSpec.describe User, type: :model do
   describe 'callback' do
     describe '管理者の削除' do
       let!(:admin_user) { create(:user, admin: true) }
+      context '管理者が2人以上の時' do
+        let!(:second_admin_user) { create(:user, admin: true) }
+        it '管理者を削除できる' do
+          expect(User.where(admin: true).size).to be > 1
+          expect { second_admin_user.destroy! }.to change { User.count }.by(-1)
+        end
+      end
       context '管理者が1人の時' do
         it '管理者を削除できない' do
-          expect(User.where(admin: true).size).to eq 1
+          expect(User.where(admin: true).count).to eq 1
           expect { admin_user.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
         end
       end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Users', type: :system do
       click_button :commit
     end
     it 'NotAuthorizedErrorが発生する' do
-      expect { visit admin_users_path }.to raise_error(ApplicationController::NotAuthorizedError)
+      expect { visit admin_users_path }.to raise_error(Admin::AdminController::NotAuthorizedError)
     end
   end
 

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -76,17 +76,20 @@ RSpec.describe 'Users', type: :system do
     end
 
     describe 'update' do
+      let(:test_user) { create(:user) }
       let(:update_user_name) { 'Change user name' }
       it 'ユーザーが編集できる' do
-        visit edit_admin_user_path(test_admin_user)
-        expect(page).to have_field 'user[name]', with: test_admin_user.name
+        visit edit_admin_user_path(test_user)
+        expect(page).to have_field 'user[name]', with: test_user.name
         fill_in 'user[name]', with: update_user_name
-        fill_in 'user[password]', with: test_admin_user.password
-        fill_in 'user[password_confirmation]', with: test_admin_user.password
+        fill_in 'user[password]', with: test_user.password
+        fill_in 'user[password_confirmation]', with: test_user.password
+        check 'user[admin]'
         click_button :commit
 
         expect(page).to have_content 'ユーザーを編集しました。'
         expect(page).to have_content update_user_name
+        expect(test_user.reload.admin?).to eq true
       end
     end
     describe 'destroy' do

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -8,13 +8,27 @@ RSpec.describe 'Users', type: :system do
     end
   end
 
-  context 'ログイン状態' do
-    let(:test_user) { create(:user) }
+  context '一般ユーザーがログイン状態の時' do
+    let(:non_admin_user) { create(:user) }
     before do
       # ログイン
       visit login_path
-      fill_in 'session[email]',	with: test_user.email
-      fill_in 'session[password]',	with: test_user.password
+      fill_in 'session[email]',	with: non_admin_user.email
+      fill_in 'session[password]',	with: non_admin_user.password
+      click_button :commit
+    end
+    it 'NotAuthorizedErrorが発生する' do
+      expect { visit admin_users_path }.to raise_error(ApplicationController::NotAuthorizedError)
+    end
+  end
+
+  context '管理者ユーザーがログイン状態の時' do
+    let(:test_admin_user) { create(:user, admin: true) }
+    before do
+      # ログイン
+      visit login_path
+      fill_in 'session[email]',	with: test_admin_user.email
+      fill_in 'session[password]',	with: test_admin_user.password
       click_button :commit
     end
 
@@ -31,17 +45,17 @@ RSpec.describe 'Users', type: :system do
       end
 
       it 'タスク数が表示される' do
-        create(:task, user: test_user)
+        create(:task, user: test_admin_user)
         visit admin_users_path
         tasks_count = find_by_id('tasks_count').text
-        expect(tasks_count).to eq test_user.tasks.count.to_s
+        expect(tasks_count).to eq test_admin_user.tasks.count.to_s
       end
     end
 
     describe 'show' do
       it 'ユーザーが表示される' do
-        visit admin_user_path(test_user)
-        expect(page).to have_content test_user.name
+        visit admin_user_path(test_admin_user)
+        expect(page).to have_content test_admin_user.name
       end
     end
 
@@ -64,11 +78,11 @@ RSpec.describe 'Users', type: :system do
     describe 'update' do
       let(:update_user_name) { 'Change user name' }
       it 'ユーザーが編集できる' do
-        visit edit_admin_user_path(test_user)
-        expect(page).to have_field 'user[name]', with: test_user.name
+        visit edit_admin_user_path(test_admin_user)
+        expect(page).to have_field 'user[name]', with: test_admin_user.name
         fill_in 'user[name]', with: update_user_name
-        fill_in 'user[password]', with: test_user.password
-        fill_in 'user[password_confirmation]', with: test_user.password
+        fill_in 'user[password]', with: test_admin_user.password
+        fill_in 'user[password_confirmation]', with: test_admin_user.password
         click_button :commit
 
         expect(page).to have_content 'ユーザーを編集しました。'


### PR DESCRIPTION
### 仕様
[ステップ22: ユーザにロールを追加しよう](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9722-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)

* ユーザに管理ユーザと一般ユーザを区別するようにしてみましょう
* 管理ユーザだけがユーザ管理画面にアクセスできるようにしてみましょう
	* 一般ユーザが管理画面にアクセスした場合、専用の例外を出してみましょう
	* 例外を補足して、適切にエラーページを表示しましょう（ステップ24で実施しても構いません）
* ユーザ管理画面でロールを選択できるようにしましょう
* 管理ユーザが1人もいなくならないように削除の制御をしましょう
	* モデルのコールバックを利用してみましょう
* ※ Gemの使用・不使用は自由です

### やったこと
1. 管理者権限のカラム追加
2. 管理画面のアクセス権限追加
3. 管理権限の編集
4. 管理者が0人にならないコールバックを追加
5. seedデータに管理者を追加

### 確認したこと
1. 管理者が追加・編集できること
2. 管理画面がアクセス制限されること
3. 管理者を1->0の削除する時、削除されないこと
4. テストが通過すること

### あえてやってないこと
* 例外のエラーページ作成（ステップ24にて作成）

### 画面
#### 管理者削除失敗時
![SS_ 2020-09-03 13 54 42](https://user-images.githubusercontent.com/43537209/92080558-b5735f00-edfc-11ea-8409-ec4ebff11f13.jpg)
