### PR TITLE
ステップ23: タスクにラベルをつけられるようにしよう

### DIFF
--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -7,14 +7,14 @@ class LabelsController < ApplicationController
     label = current_user.labels.new(label_params)
 
     if label.save
-      redirect_to tasks_path, notice: 'ラベルを作成しました。'
+      redirect_back fallback_location: tasks_path, notice: 'ラベルを作成しました。'
     else
       error_messages = if label.errors.any?
                          label.errors.full_messages.join('\n')
                        else
                          '不明な理由で、ラベルの作成に失敗しました。'
                        end
-      redirect_to tasks_path, alert: error_messages
+      redirect_back fallback_location: tasks_path, alert: error_messages
     end
   end
 

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -1,4 +1,8 @@
 class LabelsController < ApplicationController
+  def index
+    @labels = current_user.labels
+  end
+
   def create
     label = current_user.labels.new(label_params)
 

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -1,0 +1,24 @@
+class LabelsController < ApplicationController
+  def create
+    label = current_user.labels.new(label_params)
+
+    if label.save
+      redirect_to tasks_path, notice: 'ラベルを作成しました。'
+    else
+      error_messages = if label.errors.any?
+                         label.errors.full_messages.join('\n')
+                       else
+                         '不明な理由で、ラベルの作成に失敗しました。'
+                       end
+      redirect_to tasks_path, alert: error_messages
+    end
+  end
+
+  def destroy; end
+
+  private
+
+  def label_params
+    params.require(:label).permit(:name)
+  end
+end

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -18,7 +18,14 @@ class LabelsController < ApplicationController
     end
   end
 
-  def destroy; end
+  def destroy
+    label = current_user.labels.find(params[:id])
+    if label.destroy
+      redirect_back fallback_location: tasks_path, notice: 'ラベルを削除しました。'
+    else
+      redirect_back fallback_location: tasks_path, alert: 'ラベルの削除に失敗しました。'
+    end
+  end
 
   private
 

--- a/app/controllers/task_labels_controller.rb
+++ b/app/controllers/task_labels_controller.rb
@@ -5,14 +5,14 @@ class TaskLabelsController < ApplicationController
     task_label = @task.task_labels.new(task_label_params)
 
     if task_label.save
-      redirect_to tasks_path, notice: 'ラベルを付けました。'
+      redirect_back fallback_location: tasks_path, notice: 'ラベルを付けました。'
     else
       error_messages = if task_label.errors.any?
                          task_label.errors.full_messages.join('\n')
                        else
                          '不明な理由で、ラベルの添付に失敗しました。'
                        end
-      redirect_to tasks_path, alert: error_messages
+      redirect_back fallback_location: tasks_path, alert: error_messages
     end
   end
 

--- a/app/controllers/task_labels_controller.rb
+++ b/app/controllers/task_labels_controller.rb
@@ -16,7 +16,14 @@ class TaskLabelsController < ApplicationController
     end
   end
 
-  def destroy; end
+  def destroy
+    task_label = @task.task_labels.find(params[:id])
+    if task_label.destroy
+      redirect_back fallback_location: root_path, notice: 'ラベルを外しました。'
+    else
+      redirect_back fallback_location: tasks_path, alert: 'ラベルの削除に失敗しました。'
+    end
+  end
 
   private
 

--- a/app/controllers/task_labels_controller.rb
+++ b/app/controllers/task_labels_controller.rb
@@ -1,0 +1,30 @@
+class TaskLabelsController < ApplicationController
+  before_action :set_task, only: %i[create destroy]
+
+  def create
+    task_label = @task.task_labels.new(task_label_params)
+
+    if task_label.save
+      redirect_to tasks_path, notice: 'ラベルを付けました。'
+    else
+      error_messages = if task_label.errors.any?
+                         task_label.errors.full_messages.join('\n')
+                       else
+                         '不明な理由で、ラベルの添付に失敗しました。'
+                       end
+      redirect_to tasks_path, alert: error_messages
+    end
+  end
+
+  def destroy; end
+
+  private
+
+  def set_task
+    @task = Task.find(params[:task_id])
+  end
+
+  def task_label_params
+    params.require(:task_label).permit(:label_id)
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,6 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update destroy]
 
   def index
+    @my_labels = current_user.labels
     @q = current_user.tasks.ransack(params[:q])
     @tasks = @q.result.includes(:labels).page(params[:page]).order(created_at: :desc)
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
 
   def index
     @q = current_user.tasks.ransack(params[:q])
-    @tasks = @q.result.page(params[:page]).order(created_at: :desc)
+    @tasks = @q.result.includes(:labels).page(params[:page]).order(created_at: :desc)
   end
 
   def show; end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -27,7 +27,13 @@ class TasksController < ApplicationController
 
   def update
     if @task.update(task_params)
-      redirect_to @task, notice: 'タスクを編集しました。'
+      flash.notice = 'タスクを編集しました。'
+      # editページからupdateの場合はtask_pathに返す、それ以外は元のページに戻る
+      if URI.parse(request.headers['Referer']).path == edit_task_path(@task)
+        redirect_to @task
+      else
+        redirect_back fallback_location: @task
+      end
     else
       render :edit
     end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,9 @@ class TasksController < ApplicationController
     @tasks = @q.result.includes(:labels).page(params[:page]).order(created_at: :desc)
   end
 
-  def show; end
+  def show
+    @my_labels = current_user.labels
+  end
 
   def new
     @task = current_user.tasks.new

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,0 +1,6 @@
+class Label < ApplicationRecord
+  has_many :task_labels, dependent: :destroy
+  belongs_to :user
+
+  validates :name, presence: true, length: { in: 1..50 }, uniqueness: { scope: %i[name user_id] }
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,4 +12,10 @@ class Task < ApplicationRecord
   def labels_name
     labels.map(&:name)
   end
+
+  def not_attached_labels_to_select_form_values
+    current_labels = user.labels
+    no_attached_labels = current_labels - labels
+    no_attached_labels.map { |label| [label.name, label.id] }
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 class Task < ApplicationRecord
+  has_many :task_labels, dependent: :destroy
   belongs_to :user
 
   validates :name, presence: true, length: { in: 1..50 }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,6 @@
 class Task < ApplicationRecord
   has_many :task_labels, dependent: :destroy
+  has_many :labels, through: :task_labels
   belongs_to :user
 
   validates :name, presence: true, length: { in: 1..50 }
@@ -7,4 +8,8 @@ class Task < ApplicationRecord
 
   enum status: { not_started: 0, in_start: 1, completed: 2 }
   enum priority: { low: 0, middle: 1, high: 2 }
+
+  def labels_name
+    labels.map(&:name)
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -13,9 +13,8 @@ class Task < ApplicationRecord
     labels.map(&:name)
   end
 
-  def not_attached_labels_to_select_form_values
-    current_labels = user.labels
-    no_attached_labels = current_labels - labels
+  def not_attached_labels_to_select_form_values(my_labels)
+    no_attached_labels = my_labels - labels
     no_attached_labels.map { |label| [label.name, label.id] }
   end
 end

--- a/app/models/task_label.rb
+++ b/app/models/task_label.rb
@@ -2,5 +2,5 @@ class TaskLabel < ApplicationRecord
   belongs_to :task
   belongs_to :label
 
-  validates :label_id, uniqueness: { scope: %i[lebel_id task_id] }
+  validates :label_id, uniqueness: { scope: %i[label_id task_id] }
 end

--- a/app/models/task_label.rb
+++ b/app/models/task_label.rb
@@ -1,0 +1,6 @@
+class TaskLabel < ApplicationRecord
+  belongs_to :task
+  belongs_to :label
+
+  validates :label_id, uniqueness: { scope: %i[lebel_id task_id] }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,8 @@ class User < ApplicationRecord
     errors.add :admin, '管理者が0人になるため削除できません。'
     raise ActiveRecord::Rollback
   end
+
+  def labels_for_search_form
+    labels.map { |label| [label.name, label.id] }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,13 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :tasks, dependent: :destroy
-  after_destroy :one_or_more_admin_users
+  has_many :labels, dependent: :destroy
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
   validates :admin, inclusion: { in: [true, false] }
+
+  after_destroy :one_or_more_admin_users
 
   scope :join_tasks_count, -> { left_joins(:tasks).select('users.*, COUNT(tasks.id) AS tasks_count').group(:id) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,4 @@ class User < ApplicationRecord
     errors.add :admin, '管理者が0人になるため削除できません。'
     raise ActiveRecord::Rollback
   end
-
-  def labels_for_search_form
-    labels.map { |label| [label.name, label.id] }
-  end
 end

--- a/app/views/labels/index.html.slim
+++ b/app/views/labels/index.html.slim
@@ -1,0 +1,19 @@
+h1 タスク一覧
+
+= form_with url: labels_path, local: true, id: 'label_create_form' do |form|
+  .
+    = form.label :name, 'ラベル名'
+    = form.text_field 'label[name]', size: 55, maxlength: 50, required: true
+
+  = form.submit "ラベルを作成"
+
+table
+  thead
+    tr
+      th = Label.human_attribute_name(:name)
+
+  tbody
+    - @labels.each do |label|
+      tr.label_list
+        td = label.name
+        td = link_to '削除', label, method: :delete, data: { confirm: 'ラベルを削除しますか？' }

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -2,6 +2,7 @@ ul
   - if current_user
     li = link_to  "タスク一覧", tasks_path
     li = link_to  "タスク作成", new_task_path
+    li = link_to  "ラベル一覧", labels_path
     li = link_to 'ログアウト', logout_path, method: :delete
     - if current_user.admin?
       li = link_to  "ユーザ一覧", admin_users_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -10,7 +10,7 @@ h1 タスク一覧
     = f.label :status
     .
       - Task.enum_to_key_values_for_search_form(:status).each do |name, key|
-        = f.check_box :status_in, {  multiple: true }, key
+        = f.check_box :status_in, {  multiple: true }, key, nil
         = f.label "status_in_#{key}", name
 
   .

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -22,7 +22,7 @@ h1 タスク一覧
 
   = f.submit "検索"
 
-= form_with url: labels_path, local: true do |form|
+= form_with url: labels_path, local: true, id: 'label_create_form' do |form|
   .
     = form.label :name, 'ラベル名'
     = form.text_field 'label[name]', size: 55, maxlength: 50, required: true
@@ -56,7 +56,7 @@ table
             = form.submit
 
         td
-          = form_with url: task_task_labels_path(task), local: true do |form|
+          = form_with url: task_task_labels_path(task), local: true, class: 'task_labels_form' do |form|
             = select :task_label, :label_id, task.not_attached_labels_to_select_form_values(@my_labels)
             = form.submit 'ラベルを付ける'
 

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -57,7 +57,7 @@ table
 
         td
           = form_with url: task_task_labels_path(task), local: true do |form|
-            = select :task_label, :label_id, task.not_attached_labels_to_select_form_values
+            = select :task_label, :label_id, task.not_attached_labels_to_select_form_values(@my_labels)
             = form.submit 'ラベルを付ける'
 
         td = link_to '編集', edit_task_path(task)

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -13,6 +13,13 @@ h1 タスク一覧
 
   = f.submit "検索"
 
+= form_with url: labels_path, local: true do |form|
+  .
+    = form.label :name, 'ラベル名'
+    = form.text_field 'label[name]', size: 55, maxlength: 50, required: true
+
+  = form.submit "ラベルを作成"
+
 table
   thead
     tr

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -46,6 +46,11 @@ table
             = select :task, :priority, Task.enum_to_key_values_for_select_form(:priority)
             = form.submit
 
+        td
+          = form_with url: task_task_labels_path(task), local: true do |form|
+            = select :task_label, :label_id, task.not_attached_labels_to_select_form_values
+            = form.submit 'ラベルを付ける'
+
         td = link_to '編集', edit_task_path(task)
         td = link_to '削除', task, method: :delete, data: { confirm: 'タスクを削除しますか？' }
 

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -16,9 +16,7 @@ h1 タスク一覧
   .
     = f.label :label
     .
-      - current_user.labels_for_search_form.each do |name, key|
-        = name
-        = f.check_box :labels_id_in, {  multiple: true }, key, nil
+      = f.collection_check_boxes :labels_id_in, current_user.labels, :id, :name
 
   = f.submit "検索"
 

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -27,6 +27,7 @@ table
       th = sort_link @q, :end_date, Task.human_attribute_name(:end_date)
       th = Task.human_attribute_name(:status)
       th = sort_link @q, :priority, Task.human_attribute_name(:priority)
+      th = Label.human_attribute_name(:name)
 
   tbody
     - @tasks.each do |task|
@@ -35,6 +36,7 @@ table
         td = task.end_date
         td = task.human_attribute_enum(:status)
         td = task.human_attribute_enum(:priority)
+        td = task.labels_name.join(', ')
         td
           = form_with model: task, local: true, class: 'task-status-form' do |form|
             = select :task, :status, Task.enum_to_key_values_for_select_form(:status)

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -3,13 +3,22 @@ h1 タスク一覧
 = search_form_for @q do |f|
   .
     = f.label :name, 'キーワード検索'
-    = f.search_field :name_cont
+    .
+      = f.search_field :name_cont
 
   .
     = f.label :status
-    - Task.enum_to_key_values_for_search_form(:status).each do |name, key|
-      = name
-      = f.check_box :status_in, {  multiple: true }, key, nil
+    .
+      - Task.enum_to_key_values_for_search_form(:status).each do |name, key|
+        = name
+        = f.check_box :status_in, {  multiple: true }, key, nil
+
+  .
+    = f.label :label
+    .
+      - current_user.labels_for_search_form.each do |name, key|
+        = name
+        = f.check_box :labels_id_in, {  multiple: true }, key, nil
 
   = f.submit "検索"
 

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -10,8 +10,8 @@ h1 タスク一覧
     = f.label :status
     .
       - Task.enum_to_key_values_for_search_form(:status).each do |name, key|
-        = name
-        = f.check_box :status_in, {  multiple: true }, key, nil
+        = f.check_box :status_in, {  multiple: true }, key
+        = f.label "status_in_#{key}", name
 
   .
     = f.label :label

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -1,10 +1,36 @@
 h1 タスク詳細
-
 h2 = @task.name
-p = @task.description
-p
-  | 終了期限: 
-  = @task.end_date
+.
+  table
+    tbody
+      tr
+        th = Task.human_attribute_name(:description)
+        td = @task.description
+      tr
+        th = Task.human_attribute_name(:end_date)
+        td = @task.end_date
+      tr
+        th = Task.human_attribute_name(:status)
+        td = @task.human_attribute_enum(:status)
+      tr
+        th = Task.human_attribute_name(:priority)
+        td = @task.human_attribute_enum(:priority)
+      tr
+        th = Label.human_attribute_name(:name)
+        td = @task.labels_name.join(', ')
 
-= link_to '編集', edit_task_path(@task.id)
+= link_to '編集', edit_task_path(@task.id), id: 'task_edit'
 = link_to ' 削除', @task, method: :delete, id: 'task_delete', data: { confirm: 'タスクを削除しますか？' }
+
+= form_with model: @task, local: true, class: 'task-status-form' do |form|
+  = select :task, :status, Task.enum_to_key_values_for_select_form(:status)
+  . = form.submit
+
+= form_with model: @task, local: true, class: 'task-priority-form' do |form|
+  = select :task, :priority, Task.enum_to_key_values_for_select_form(:priority)
+  . = form.submit
+
+= form_with url: task_task_labels_path(@task), local: true, class: 'task_labels_form' do |form|
+  = select :task_label, :label_id, @task.not_attached_labels_to_select_form_values(@my_labels)
+  . = form.submit 'ラベルを付ける'
+

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -17,7 +17,11 @@ h2 = @task.name
         td = @task.human_attribute_enum(:priority)
       tr
         th = Label.human_attribute_name(:name)
-        td = @task.labels_name.join(', ')
+        td
+          - @task.task_labels.includes(:label).each do |task_label|
+            = task_label.label.name
+            = link_to '外す', task_task_label_path(task_label.task_id, task_label.id), method: :delete
+
 
 = link_to '編集', edit_task_path(@task.id), id: 'task_edit'
 = link_to ' 削除', @task, method: :delete, id: 'task_delete', data: { confirm: 'タスクを削除しますか？' }
@@ -33,4 +37,3 @@ h2 = @task.name
 = form_with url: task_task_labels_path(@task), local: true, class: 'task_labels_form' do |form|
   = select :task_label, :label_id, @task.not_attached_labels_to_select_form_values(@my_labels)
   . = form.submit 'ラベルを付ける'
-

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,6 +18,7 @@ ja:
         end_date: 終了期限
         status: ステータス
         priority: 優先順位
+        label: ラベル
       task/status:
         not_started: 未着手
         in_start: 着手中

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
     models:
       task: タスク
       user: ユーザー
+      label: ラベル
     attributes:
       user:
         email: メールアドレス
@@ -25,6 +26,8 @@ ja:
         low: 低
         middle: 中
         high: 高
+      label:
+        name: ラベル
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -29,6 +29,10 @@ ja:
         high: 高
       label:
         name: ラベル
+        user_id: ユーザー
+      task_label:
+        label_id: ラベル
+        user_id: ユーザー
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
     end
   end
   resources :tasks
+  resources :labels, only: %i[create destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
   resources :tasks do
     resources :task_labels, only: %i[create destroy]
   end
-  resources :labels, only: %i[create destroy]
+  resources :labels, only: %i[index create destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
       resources :tasks, only: :index
     end
   end
-  resources :tasks
+  resources :tasks do
+    resources :task_labels, only: %i[create destroy]
+  end
   resources :labels, only: %i[create destroy]
 end

--- a/db/migrate/20200903074922_create_labels.rb
+++ b/db/migrate/20200903074922_create_labels.rb
@@ -1,0 +1,11 @@
+class CreateLabels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :labels do |t|
+      t.timestamps
+
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.index %i[user_id name], unique: true
+    end
+  end
+end

--- a/db/migrate/20200903075053_create_task_labels.rb
+++ b/db/migrate/20200903075053_create_task_labels.rb
@@ -1,0 +1,11 @@
+class CreateTaskLabels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :task_labels do |t|
+      t.timestamps
+
+      t.references :task, null: false, foreign_key: true
+      t.references :label, null: false, foreign_key: true
+      t.index %i[task_id label_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_03_031023) do
+ActiveRecord::Schema.define(version: 2020_09_03_075053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "labels", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.index ["user_id", "name"], name: "index_labels_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_labels_on_user_id"
+  end
+
+  create_table "task_labels", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "task_id", null: false
+    t.bigint "label_id", null: false
+    t.index ["label_id"], name: "index_task_labels_on_label_id"
+    t.index ["task_id", "label_id"], name: "index_task_labels_on_task_id_and_label_id", unique: true
+    t.index ["task_id"], name: "index_task_labels_on_task_id"
+  end
 
   create_table "tasks", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
@@ -44,5 +63,8 @@ ActiveRecord::Schema.define(version: 2020_09_03_031023) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "labels", "users"
+  add_foreign_key "task_labels", "labels"
+  add_foreign_key "task_labels", "tasks"
   add_foreign_key "tasks", "users"
 end

--- a/spec/factories/label.rb
+++ b/spec/factories/label.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :label do
+    user
+    name { 'テストラベル' }
+  end
+end

--- a/spec/factories/task_label.rb
+++ b/spec/factories/task_label.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :task_label do
+    task
+    label
+  end
+end

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  describe 'validate' do
+    let(:label) { build(:label) }
+    it { expect(label).to be_valid }
+
+    context '同じラベル名を2つ作ったとき' do
+      let(:user) { create(:user) }
+      let(:first_label) { build(:label, name: '同じラベル', user: user) }
+      let(:second_label) { build(:label, name: '同じラベル', user: user) }
+      it '失敗する' do
+        first_label.save!
+        expect(second_label).to be_invalid
+        expect(second_label.errors.full_messages).to include 'ラベルはすでに存在します'
+      end
+    end
+  end
+end

--- a/spec/models/task_label_spec.rb
+++ b/spec/models/task_label_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe TaskLabel, type: :model do
+  describe 'validate' do
+    let(:task_label) { build(:task_label) }
+    it { expect(task_label).to be_valid }
+  end
+
+  context '同じラベルを2個以上付けた時' do
+    let(:user) { create(:user) }
+    let(:task) { create(:task, user: user) }
+    let(:label) { create(:label, user: user) }
+    let(:first_task_label) { build(:task_label, task: task, label: label) }
+    let(:second_task_label) { build(:task_label, task: task, label: label) }
+    it '失敗する' do
+      first_task_label.save!
+      expect(second_task_label).to be_invalid
+      expect(second_task_label.errors.full_messages).to include 'ラベルはすでに存在します'
+    end
+  end
+end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Tasks', type: :system do
           expect(tasks[0]).to have_content target_task.name
           expect(tasks[1]).to have_content non_target_task.name
 
-          # タスクを入��して検索
+          # タスク名を入力して検索
           within find_by_id('task_search') do
             fill_in 'q[name_cont]', with: target_task.name
             click_button :commit


### PR DESCRIPTION
### 仕様
[ステップ23: タスクにラベルをつけられるようにしよう](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9723-%E3%82%BF%E3%82%B9%E3%82%AF%E3%81%AB%E3%83%A9%E3%83%99%E3%83%AB%E3%82%92%E3%81%A4%E3%81%91%E3%82%89%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)

* タスクに複数のラベルをつけられるようにしてみましょう
* つけたラベルで検索できるようにしてみましょう

### やったこと
1. ラベル・タスクとラベルの中間テーブル作成
2. ラベルの一覧・作成・削除機能の実装
3. タスクにラベルを付ける・外す機能の実装
4. 編集ページ以外からの作成・編集・削除は戻るページを利用するようにした
5. 各種機能のテストを作成

### 確認したこと
* ラベルの一覧・作成・削除ができること
* タスクにラベルを付け・外しができること
* ラベルの検索ができること
* テストが通過すること

### 画面
#### ラベル機能の実演
![ラベル機能](https://user-images.githubusercontent.com/43537209/92213414-77df0680-eece-11ea-9792-6c02b5bf0917.gif)
